### PR TITLE
Fix gateway timeout

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -32,5 +32,6 @@ http {
     #gzip  on;
 
     include /etc/nginx/sites-enabled/*;
+    fastcgi_read_timeout 3000;
 }
 daemon off;


### PR DESCRIPTION
The problem is: if we use elasticsearch php library to [scroll](https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_search_operations.html#_scan_scroll) through documents, we will get 504 gateway timeout error by nginx.

The simple fix is increase [fastcgi_read_timeout](http://stackoverflow.com/a/40134530). I set to 30000 as suggested [here](http://www.codetweet.com/nginx/solved-504-gateway-timeout-error-in-nginx-web-server/)