### PR TITLE
Increase buffer size to fix 502 bad gateway error

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -32,6 +32,11 @@ http {
     #gzip  on;
 
     include /etc/nginx/sites-enabled/*;
+
+    fastcgi_buffers 8 16k;
+    fastcgi_buffer_size 32k;
+    fastcgi_connect_timeout 3000;
+    fastcgi_send_timeout 3000;
     fastcgi_read_timeout 3000;
 }
 daemon off;


### PR DESCRIPTION
The error is:
`error] 97#97: *545 recv() failed (104: Connection reset by peer) while reading response header from upstream`

Follow instruction here http://jvdc.me/fix-502-bad-gateway-error-on-nginx-server-after-upgrading-php/