### PR TITLE
Disable etag caching

### DIFF
--- a/rootfs/etc/nginx/sites-available/default.conf
+++ b/rootfs/etc/nginx/sites-available/default.conf
@@ -28,6 +28,7 @@ server {
 
     error_log /dev/stderr notice;
     access_log /dev/stdout trace;
+    etag off;
 
     location / {
         # First attempt to serve request as file, then


### PR DESCRIPTION
Disable etag, we don't handle etag caching at micro-service layer:

- Cache duplications on service, api, gateway.
- We can't invalidate the cache.

Ref: http://nginx.org/en/docs/http/ngx_http_core_module.html#etag